### PR TITLE
Fix hashing in browser.js

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,7 +2,7 @@ module.exports = sha256
 module.exports.sync = sha256sync
 
 const crypto = globalThis.crypto || globalThis.msCrypto
-const subtle = crypto.subtle || crypto.webkitSubtle
+const subtle = crypto.subtle || crypto.webkitSubtle || (crypto.webcrypto && crypto.webcrypto.subtle)
 
 function sha256sync (buf) {
   throw new Error('No support for sha256.sync() in the browser, use sha256()')

--- a/browser.js
+++ b/browser.js
@@ -13,7 +13,7 @@ async function sha256 (buf) {
 
   // Browsers throw if they lack support for an algorithm.
   // Promise will be rejected on non-secure origins. (http://goo.gl/lq4gCo)
-  const hash = subtle.digest({ name: 'sha-256' }, buf)
+  const hash = await subtle.digest({ name: 'sha-256' }, buf)
   return hex(new Uint8Array(hash))
 }
 

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,0 +1,36 @@
+// These tests are not run on node versions prior to 14, as they lack webcrypto.
+
+const crypto = require('crypto')
+
+if (!globalThis.crypto) {
+  globalThis.crypto = crypto
+}
+
+const sha256 = require('../browser')
+const test = require('tape')
+
+if (globalThis.crypto.webcrypto) {
+  const TEXT = 'hey there'
+  const HASH = '74ef874a9fa69a86e091ea6dc2668047d7e102d518bebed19f8a3958f664e3da'
+
+  test('sha256', function (t) {
+    t.plan(2)
+
+    // buffer
+    sha256(Buffer.from(TEXT)).then(hash => {
+      t.equal(hash, HASH)
+    })
+    // string
+    sha256(TEXT).then(hash => {
+      t.equal(hash, HASH)
+    })
+  })
+
+  test('sha256.sync', function (t) {
+    t.throws(function () {
+      sha256.sync(Buffer.from(TEXT))
+    }, /No support for sha256\.sync\(\) in the browser, use sha256\(\)/)
+
+    t.end()
+  })
+}


### PR DESCRIPTION
Missing "await" for subtle.digest means that any hash created by browser.js ends up being just an empty string.